### PR TITLE
move html generation of policy to to_html method

### DIFF
--- a/app/models/scaptimony/policy.rb
+++ b/app/models/scaptimony/policy.rb
@@ -13,26 +13,40 @@ module Scaptimony
     def assign_assets(a)
       self.asset_ids = (self.asset_ids + a.collect(&:id)).uniq
     end
-  end
 
-  class GuideGenerator
-    def initialize(p)
-      case p
-      when Scaptimony::Policy
-        @scap_content = p.scap_content
-        @profile = p.scap_content_profile
+    def to_html
+      if self.scap_content.blank? || self.scap_content_profile.blank?
+        return warn(_('Cannot generate HTML guide for %{scap_content}/%{profile}') % {:scap_content => self.scap_content, :profile => self.scap_content_profile})
       end
-      if @scap_content.nil? or @scap_content.source.nil?
-        OpenSCAP.raise! "Cannot generate HTML Guide for #{@scap_content}/#{@profile}"
-      end
-    end
 
-    def each
-      sds = OpenSCAP::DS::Sds.new @scap_content.source
+      sds = OpenSCAP::DS::Sds.new self.scap_content.source
       sds.select_checklist
-      profile_id = @profile.nil? ? nil : @profile.profile_id
-      yield sds.html_guide profile_id
+      profile_id = self.scap_content_profile.nil? ? nil : self.scap_content_profile.profile_id
+      html = sds.html_guide profile_id
       sds.destroy
+      html
     end
   end
+
+  # ## Remove this class if it is un-used elsewhere. move to lib if needed by others.
+  # class GuideGenerator
+  #   def initialize(p)
+  #     case p
+  #     when Scaptimony::Policy
+  #       @scap_content = p.scap_content
+  #       @profile = p.scap_content_profile
+  #     end
+  #     if @scap_content.nil? or @scap_content.source.nil?
+  #       OpenSCAP.raise! "Cannot generate HTML Guide for #{@scap_content}/#{@profile}"
+  #     end
+  #   end
+  #
+  #   def each
+  #     sds = OpenSCAP::DS::Sds.new @scap_content.source
+  #     sds.select_checklist
+  #     profile_id = @profile.nil? ? nil : @profile.profile_id
+  #     yield sds.html_guide profile_id
+  #     sds.destroy
+  #   end
+  # end
 end


### PR DESCRIPTION
@isimluk - I have commented out `GuideGenerator` from here and created a to_html method, which does the same.
If `GuideGenerator` is not needed. I'll remove it completely.
