### PR TITLE
fixes OpenSCAP/foreman_openscap#4 - Support deletion of scap_content

### DIFF
--- a/app/models/scaptimony/scap_content.rb
+++ b/app/models/scaptimony/scap_content.rb
@@ -33,7 +33,9 @@ module Scaptimony
 
   class ScapContent < ActiveRecord::Base
     has_many :scap_content_profiles, :dependent => :destroy
-    has_many :policies, :dependent => :destroy
+    has_many :policies
+
+    before_destroy EnsureNotUsedBy.new(:policies)
 
     validates_with Scaptimony::DataStreamValidator
     validates :title, :presence => true

--- a/db/migrate/20141104164201_create_scaptimony_scap_contents.rb
+++ b/db/migrate/20141104164201_create_scaptimony_scap_contents.rb
@@ -1,10 +1,7 @@
 class CreateScaptimonyScapContents < ActiveRecord::Migration
   def change
     create_table :scaptimony_scap_contents do |t|
-      t.string :digest, limit: 128
-
       t.timestamps
     end
-    add_index :scaptimony_scap_contents, :digest, unique: true
   end
 end


### PR DESCRIPTION
Ensures that there are no related policies to scap_content before deletion.
(when this is merged, I'll add option to delete in the controller.)
Also, removed `digest` column from migration.
