### PR TITLE
Fix failing migration

### DIFF
--- a/db/migrate/20141111104519_add_constraint_to_scaptimony_scap_contents.rb
+++ b/db/migrate/20141111104519_add_constraint_to_scaptimony_scap_contents.rb
@@ -1,6 +1,5 @@
 class AddConstraintToScaptimonyScapContents < ActiveRecord::Migration
   def change
     change_column :scaptimony_scap_contents, :title, :string, :null => false
-    change_column :scaptimony_scap_contents, :digest, :string, :null => false
   end
 end


### PR DESCRIPTION
This column does to exist. Either `scaptimony_arf_reports` digest column was meant or we should remove this line.