### PR TITLE
Arf report in db

### DIFF
--- a/app/models/scaptimony/arf_report.rb
+++ b/app/models/scaptimony/arf_report.rb
@@ -11,6 +11,7 @@ module Scaptimony
     belongs_to :policy
     delegate :assetable, :to => :asset, :as => :assetable
     has_many :xccdf_rule_results, :dependent => :destroy
+    has_one :arf_report_raw, :dependent => :destroy
     has_one :arf_report_breakdown
 
     before_destroy :delete

--- a/app/models/scaptimony/arf_report_raw.rb
+++ b/app/models/scaptimony/arf_report_raw.rb
@@ -41,7 +41,7 @@ module Scaptimony
 
     def build_arf
       OpenSCAP.oscap_init
-      OpenSCAP::DS::Arf.new :content => raw, :path => 'arf.xml.bz2', :length => size
+      OpenSCAP::DS::Arf.new :content => bzip_data, :path => 'arf.xml.bz2', :length => size
     end
   end
 end

--- a/app/models/scaptimony/arf_report_raw.rb
+++ b/app/models/scaptimony/arf_report_raw.rb
@@ -1,0 +1,6 @@
+module Scaptimony
+  class ArfReportRaw < ActiveRecord::Base
+    set_primary_key :arf_report_id
+    belongs_to :arf_report
+  end
+end

--- a/app/models/scaptimony/arf_report_raw.rb
+++ b/app/models/scaptimony/arf_report_raw.rb
@@ -25,10 +25,7 @@ module Scaptimony
       begin
         arf = build_arf
         test_result = arf.test_result
-        test_result.rr.each {|rr_id, rr|
-          rule = ::Scaptimony::XccdfRule.where(:xid => rr_id).first_or_create!
-          arf_report.xccdf_rule_results.create!(:xccdf_rule_id => rule.id, :xccdf_result_id => XccdfResult.f(rr.result).id)
-        }
+        create_rule_results(test_result)
       rescue StandardError => e
         arf_report.xccdf_rule_results.destroy_all
         raise e
@@ -37,6 +34,13 @@ module Scaptimony
         arf.destroy unless arf.nil?
         OpenSCAP.oscap_cleanup
       end
+    end
+
+    def create_rule_results(test_result)
+      test_result.rr.each {|rr_id, rr|
+        rule = ::Scaptimony::XccdfRule.where(:xid => rr_id).first_or_create!
+        arf_report.xccdf_rule_results.create!(:xccdf_rule_id => rule.id, :xccdf_result_id => XccdfResult.f(rr.result).id)
+      }
     end
 
     def build_arf

--- a/app/models/scaptimony/arf_report_raw.rb
+++ b/app/models/scaptimony/arf_report_raw.rb
@@ -1,6 +1,47 @@
+require 'openscap'
+require 'openscap/ds/arf'
+require 'openscap/xccdf/testresult'
+require 'openscap/xccdf/ruleresult'
+
 module Scaptimony
   class ArfReportRaw < ActiveRecord::Base
     set_primary_key :arf_report_id
     belongs_to :arf_report
+    after_create :save_dependent_entities
+
+    def to_html
+      arf = build_arf
+      html = arf.html
+      arf.destroy
+      OpenSCAP.oscap_cleanup
+      html
+    end
+
+    private
+
+    def save_dependent_entities
+      return if arf_report.xccdf_rule_results.any?
+      return if size < 0
+      begin
+        arf = build_arf
+        test_result = arf.test_result
+        test_result.rr.each {|rr_id, rr|
+          rule = ::Scaptimony::XccdfRule.where(:xid => rr_id).first_or_create!
+          arf_report.xccdf_rule_results.create!(:xccdf_rule_id => rule.id, :xccdf_result_id => XccdfResult.f(rr.result).id)
+        }
+      rescue StandardError => e
+        arf_report.xccdf_rule_results.destroy_all
+        raise e
+      ensure
+        test_result.destroy unless test_result.nil?
+        arf.destroy unless arf.nil?
+        OpenSCAP.oscap_cleanup
+      end
+    end
+
+    def build_arf
+      OpenSCAP.oscap_init
+      OpenSCAP::DS::Arf.new :content => raw, :path => 'arf.xml.bz2', :length => size
+    end
   end
 end

--- a/db/migrate/20150112152944_create_scaptimony_arf_report_raws.rb
+++ b/db/migrate/20150112152944_create_scaptimony_arf_report_raws.rb
@@ -1,0 +1,10 @@
+class CreateScaptimonyArfReportRaws < ActiveRecord::Migration
+  def change
+    create_table :scaptimony_arf_report_raws, :id => false do |t|
+      t.references :arf_report, :index => true, :null => false
+      t.integer :size
+      t.binary :raw
+    end
+    add_index :scaptimony_arf_report_raws, [:arf_report_id], :unique => true
+  end
+end

--- a/db/migrate/20150114210634_rename_scaptimony_arf_report_raw_raw.rb
+++ b/db/migrate/20150114210634_rename_scaptimony_arf_report_raw_raw.rb
@@ -1,0 +1,5 @@
+class RenameScaptimonyArfReportRawRaw < ActiveRecord::Migration
+  def change
+    rename_column :scaptimony_arf_report_raws, :raw, :bzip_data
+  end
+end

--- a/extra/rubygem-scaptimony.spec
+++ b/extra/rubygem-scaptimony.spec
@@ -32,13 +32,13 @@ Source0: %{gem_name}-%{version}.gem
 Requires: %{?scl_prefix}ruby(release)
 Requires: %{?scl_prefix}ruby(rubygems)
 Requires: %{?scl_prefix}rubygem(deface)
-Requires: %{?scl_prefix}rubygem(openscap) >= 0.4.0
+Requires: %{?scl_prefix}rubygem(openscap) >= 0.4.1
 BuildRequires: %{?scl_prefix}ruby(release)
 %else
 Requires: %{?scl_prefix}ruby(abi) >= %{rubyabi}
 Requires: %{?scl_prefix}rubygems
 Requires: %{?scl_prefix}rubygem-deface
-Requires: %{?scl_prefix}rubygem-openscap >= 0.4.0
+Requires: %{?scl_prefix}rubygem-openscap >= 0.4.1
 BuildRequires: %{?scl_prefix}ruby(abi) >= %{rubyabi}
 %endif
 BuildRequires: %{?scl_prefix}rubygems-devel

--- a/lib/scaptimony/arf_reports_helper.rb
+++ b/lib/scaptimony/arf_reports_helper.rb
@@ -12,7 +12,7 @@ require 'digest'
 
 module Scaptimony
   module ArfReportsHelper
-    def self.create_arf(asset, params, arf_bzip)
+    def self.create_arf(asset, params, arf_bzip, arf_bzip_size)
       # fail if policy does not exist.
       policy = Policy.find_by_name!(params[:policy])
       digest = Digest::SHA256.hexdigest arf_bzip
@@ -20,6 +20,8 @@ module Scaptimony
       arf_report = ArfReport.where(:asset_id => asset.id, :policy_id => policy.id,
                                    :date => params[:date], :digest => digest).first_or_create!
       arf_report.store!(arf_bzip)
+      return unless arf_report.arf_report_raw.nil?
+      ArfReportRaw.where(:arf_report_id => arf_report.id, :size => arf_bzip_size, :raw => arf_bzip).create!
     end
   end
 end

--- a/lib/scaptimony/arf_reports_helper.rb
+++ b/lib/scaptimony/arf_reports_helper.rb
@@ -19,7 +19,6 @@ module Scaptimony
       # TODO:RAILS-4.0: This should become arf_report = ArfReport.find_or_create_by! ...
       arf_report = ArfReport.where(:asset_id => asset.id, :policy_id => policy.id,
                                    :date => params[:date], :digest => digest).first_or_create!
-      arf_report.store!(arf_bzip)
       return unless arf_report.arf_report_raw.nil?
       ArfReportRaw.where(:arf_report_id => arf_report.id, :size => arf_bzip_size, :raw => arf_bzip).create!
     end

--- a/lib/scaptimony/arf_reports_helper.rb
+++ b/lib/scaptimony/arf_reports_helper.rb
@@ -20,7 +20,7 @@ module Scaptimony
       arf_report = ArfReport.where(:asset_id => asset.id, :policy_id => policy.id,
                                    :date => params[:date], :digest => digest).first_or_create!
       return unless arf_report.arf_report_raw.nil?
-      ArfReportRaw.where(:arf_report_id => arf_report.id, :size => arf_bzip_size, :raw => arf_bzip).create!
+      ArfReportRaw.where(:arf_report_id => arf_report.id, :size => arf_bzip_size, :bzip_data => arf_bzip).create!
     end
   end
 end

--- a/lib/scaptimony/engine.rb
+++ b/lib/scaptimony/engine.rb
@@ -1,9 +1,5 @@
 module Scaptimony
   class Engine < ::Rails::Engine
     isolate_namespace Scaptimony
-    def self.dir
-      # TODO this should be configurable
-      '/var/lib/foreman/scaptimony'
-    end
   end
 end

--- a/test/models/scaptimony/arf_report_raw_test.rb
+++ b/test/models/scaptimony/arf_report_raw_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+module Scaptimony
+  class ArfReportRawTest < ActiveSupport::TestCase
+    # test "the truth" do
+    #   assert true
+    # end
+  end
+end


### PR DESCRIPTION
This will finally put the remaining piece to the PostgreSQL database.

I have chosen to create separate table (ArfReportRaw) to hold the ARF bzip. There are two reasons behind this decision:
(1) it will help us encapsulate rubygem-openscap usage to separate class
(2) performance -- many queries fetch ArfReport, but they never really need to work with bzip file. Fetching many blob unnecessarily would be overhead for rails machinery.