### PR TITLE
ensure asset_policy is exists when arf_report is created

### DIFF
--- a/lib/scaptimony/arf_reports_helper.rb
+++ b/lib/scaptimony/arf_reports_helper.rb
@@ -20,6 +20,9 @@ module Scaptimony
       arf_report = ArfReport.where(:asset_id => asset.id, :policy_id => policy.id,
                                    :date => params[:date], :digest => digest).first_or_create!
       arf_report.store!(arf_bzip)
+
+      ## Ensure asset <-> policy exists.
+      AssetPolicy.where(:asset_id => asset.id, :policy_id => policy.id).first_or_create!
     end
   end
 end


### PR DESCRIPTION
Haven't seen anywhere where AssetPolicy is created. Think it's a good place to couple it to the creation of arf_report.
