### PR TITLE
display html error if no scap_content_profile

### DIFF
--- a/app/models/scaptimony/policy.rb
+++ b/app/models/scaptimony/policy.rb
@@ -21,8 +21,8 @@ module Scaptimony
 
     def to_html
       if self.scap_content.blank? || self.scap_content_profile.blank?
-        return warn(_('Cannot generate HTML guide for %{scap_content}/%{profile}') %
-          { :scap_content => self.scap_content, :profile => self.scap_content_profile })
+        return (_('<h2>Cannot generate HTML guide for %{scap_content}/%{profile}</h2>') %
+          { :scap_content => self.scap_content, :profile => self.scap_content_profile }).html_safe
       end
 
       sds = OpenSCAP::DS::Sds.new self.scap_content.source


### PR DESCRIPTION
On policies, if no scap_content_profile is chosen, View guide page will raise an error:
```ruby
ActionView::MissingTemplate (Missing template scaptimony_policies/parse, application/parse with {:locale=>[:en], :formats=>[:html], :handlers=>[:erb, :builder, :rabl]}. Searched in:
  * "/home/szadok/dev/repos/foreman/app/views"
  * "/home/szadok/dev/repos/foreman-docker/app/views"
  * "/home/szadok/dev/repos/foreman_openscap/app/views"
  * "/home/szadok/dev/repos/scaptimony/app/views"
  * "/home/szadok/.rvm/gems/ruby-2.0.0-p481/gems/apipie-rails-0.2.6/app/views"
):
```
We can not use ```warn``` method.