### PR TITLE
fixes issue #22 - support creating view in sqlite3 database

### DIFF
--- a/db/migrate/20141121164042_replace_arf_report_breakdown_view.rb
+++ b/db/migrate/20141121164042_replace_arf_report_breakdown_view.rb
@@ -1,7 +1,8 @@
 class ReplaceArfReportBreakdownView < ActiveRecord::Migration
   def self.up
+    execute 'DROP VIEW scaptimony_arf_report_breakdowns' if table_exists? 'scaptimony_arf_report_breakdowns'
     execute <<-SQL
-CREATE OR REPLACE VIEW scaptimony_arf_report_breakdowns AS
+CREATE VIEW scaptimony_arf_report_breakdowns AS
   SELECT
     arf.id as arf_report_id,
     COUNT(CASE WHEN result.name IN ('pass','fixed') THEN 1 ELSE null END) as passed,


### PR DESCRIPTION
```CREATE OR REPLACE VIEW``` is not supported on sqlite3 and [fails build on sqlite3](http://ci.theforeman.org/job/test_plugin_matrix/148/).
The suggested fix enables creating the view on postgres, mysql & sqlite3 