### PR TITLE
fixes #11057 & issue #24 - make digest migration conditional

### DIFF
--- a/db/migrate/20150115155947_add_scaptimony_scap_content_digest.rb
+++ b/db/migrate/20150115155947_add_scaptimony_scap_content_digest.rb
@@ -2,12 +2,14 @@ require 'digest/sha2'
 
 class AddScaptimonyScapContentDigest < ActiveRecord::Migration
   def change
-    add_column :scaptimony_scap_contents, :digest, :string, :limit => 128
-    ScapContentHack.find_each do |content|
-      content.digest
-      content.save!
+    unless column_exists?(:scaptimony_scap_contents, :digest)
+      add_column :scaptimony_scap_contents, :digest, :string, :limit => 128
+      ScapContentHack.find_each do |content|
+        content.digest
+        content.save!
+      end
+      change_column :scaptimony_scap_contents, :digest, :string, :null => false
     end
-    change_column :scaptimony_scap_contents, :digest, :string, :null => false
   end
 
   class ScapContentHack < ActiveRecord::Base


### PR DESCRIPTION
Seems that in there is no need to re-generate digest column (it was previously removed, but removal has been removed...)
Keeping this will ensure that if it doesn't exist (older version), it will add it.