### PR TITLE
Drop view with sql IF EXISTS

### DIFF
--- a/db/migrate/20141121164042_replace_arf_report_breakdown_view.rb
+++ b/db/migrate/20141121164042_replace_arf_report_breakdown_view.rb
@@ -1,6 +1,6 @@
 class ReplaceArfReportBreakdownView < ActiveRecord::Migration
   def self.up
-    execute 'DROP VIEW scaptimony_arf_report_breakdowns' if table_exists? 'scaptimony_arf_report_breakdowns'
+    execute 'DROP VIEW IF EXISTS scaptimony_arf_report_breakdowns'
     execute <<-SQL
 CREATE VIEW scaptimony_arf_report_breakdowns AS
   SELECT


### PR DESCRIPTION
```if table_exists? 'scaptimony_arf_report_breakdowns'``` apparently did not play well with sqlite3 :cry: 
This solution has been tested with sqlite 3.8.8.3 and postgres 9.1

This solutions is supported in 
[PG 8.2+](http://www.postgresql.org/docs/8.2/static/sql-dropview.html)
[SQLite 3.3.8+](https://www.sqlite.org/changes.html#version_3_3_8)
[MySQL 5.0+](https://dev.mysql.com/doc/refman/5.0/en/drop-view.html)

(Thanks @domcleal for testing and raising the issue on SQLite3)