### PR TITLE
Ensure MySql creates LONGBLOB binary fields

### DIFF
--- a/db/migrate/20151123082935_add_limit_to_binary.rb
+++ b/db/migrate/20151123082935_add_limit_to_binary.rb
@@ -1,0 +1,6 @@
+class AddLimitToBinary < ActiveRecord::Migration
+  def change
+    change_column :scaptimony_scap_contents, :scap_file, :binary, :limit => 16.megabyte
+    change_column :scaptimony_arf_report_raws, :bzip_data, :binary, :limit => 16.megabyte
+  end
+end


### PR DESCRIPTION
As reported in #31, mysql creates a 65k limited blob.
This fix ensures that mysql will create LONGBLOB. This does not affect postgres